### PR TITLE
fix: pin trivy-action to SHA (security hardening)

### DIFF
--- a/.github/workflows/trivy_docker.yaml
+++ b/.github/workflows/trivy_docker.yaml
@@ -28,7 +28,7 @@
 
 #       # scan image for vulns
 #       - name: Scan Docker Image with Trivy vulnerability scanner
-#         uses: aquasecurity/trivy-action@master
+#         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
 #         with:
 #           image-ref: 'laa-record-link-service:latest'
 #           # exit-code: 1

--- a/.github/workflows/trivy_docker.yaml
+++ b/.github/workflows/trivy_docker.yaml
@@ -28,7 +28,7 @@
 
 #       # scan image for vulns
 #       - name: Scan Docker Image with Trivy vulnerability scanner
-#         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
+#         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
 #         with:
 #           image-ref: 'laa-record-link-service:latest'
 #           # exit-code: 1


### PR DESCRIPTION
## What

Pin `aquasecurity/trivy-action` from `@master` to the commit SHA for v0.34.1 (`e368e328979b113139d6f9068e03accaed98a518`).

## Why

On 28 February 2026, the [aquasecurity/trivy](https://github.com/aquasecurity/trivy) repository was compromised as part of the [hackerbot-claw GitHub Actions exploitation campaign](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation-campaign). The attacker gained full control of the repo via a stolen PAT, renamed the default branch, deleted all releases, and pushed a malicious VS Code extension.

Referencing `trivy-action@master` means our workflow pulls whatever code is on the `master` branch at run time. During the compromise window, this could have meant executing attacker-controlled code with access to this repo's secrets and a write-scoped `GITHUB_TOKEN`.

SHA pinning is immune to this class of attack because commit hashes are immutable — even if the repo is fully compromised, an attacker cannot change what a SHA resolves to.

## Additional notes

- This is part of an org-wide security hardening effort following the hackerbot-claw incident
